### PR TITLE
Add Vararg support in embedded defs

### DIFF
--- a/core/src/main/scala/squid/quasi/ClassEmbedding.scala
+++ b/core/src/main/scala/squid/quasi/ClassEmbedding.scala
@@ -182,13 +182,14 @@ class ClassEmbedding(override val c: whitebox.Context) extends QuasiMacros(c) { 
     val clsDefTparams = clsDef.tparams map (stripVariance(_))
     
     // Makes the parameters acceptable for being lambda parameters: removes the `rhs`
+    // TODO handle by-name
     def fixValDef(vd: ValDef) = vd.tpt match {
       case AppliedTypeTree(Select(_, TypeName("<repeated>")), args) =>
         val newTypeTree = tq"Seq[..$args]"
         ValDef(vd.mods, vd.name, newTypeTree, EmptyTree)
 
       case _ => ValDef(vd.mods, vd.name, vd.tpt, EmptyTree)
-    } // TODO handle by-name and repeated
+    }
     
     val (objDefs, objMirrorDefs, objRefs) = allDefs collect {
       case inClass -> ValOrDefDef(mods, name, tparams, vparamss, tpt, rhs) if name != termNames.CONSTRUCTOR && rhs.nonEmpty => // TODO sthg about parameter accessors?

--- a/core/src/main/scala/squid/quasi/ClassEmbedding.scala
+++ b/core/src/main/scala/squid/quasi/ClassEmbedding.scala
@@ -182,7 +182,13 @@ class ClassEmbedding(override val c: whitebox.Context) extends QuasiMacros(c) { 
     val clsDefTparams = clsDef.tparams map (stripVariance(_))
     
     // Makes the parameters acceptable for being lambda parameters: removes the `rhs`
-    def fixValDef(vd: ValDef) = ValDef(vd.mods, vd.name, vd.tpt, EmptyTree) // TODO handle by-name and repeated
+    def fixValDef(vd: ValDef) = vd.tpt match {
+      case AppliedTypeTree(Select(_, TypeName("<repeated>")), args) =>
+        val newTypeTree = tq"Seq[..$args]"
+        ValDef(vd.mods, vd.name, newTypeTree, EmptyTree)
+
+      case _ => ValDef(vd.mods, vd.name, vd.tpt, EmptyTree)
+    } // TODO handle by-name and repeated
     
     val (objDefs, objMirrorDefs, objRefs) = allDefs collect {
       case inClass -> ValOrDefDef(mods, name, tparams, vparamss, tpt, rhs) if name != termNames.CONSTRUCTOR && rhs.nonEmpty => // TODO sthg about parameter accessors?

--- a/core/src/main/scala/squid/utils/meta/UniverseHelpers.scala
+++ b/core/src/main/scala/squid/utils/meta/UniverseHelpers.scala
@@ -99,7 +99,16 @@ trait UniverseHelpers[U <: scala.reflect.api.Universe] {
       case DefDef(mods, name, tparams, vparams, tpt, rhs) => Some(mods, name, tparams, vparams, tpt, rhs)
     }
   }
-  
+
+  object SequenceType {
+    val seqSym = typeOf[Seq[Any]].typeSymbol.asType
+
+    val scalaPackage = seqSym.owner.asType.toType
+
+    def apply(tpe: Type) = internal.typeRef(scalaPackage, seqSym, List(tpe))
+
+  }
+
   object FunctionType { // TODO complete with all functions types!
     
     val Fun0Sym = typeOf[() => Any].typeSymbol.asType

--- a/core/src/main/scala/squid/utils/meta/UniverseHelpers.scala
+++ b/core/src/main/scala/squid/utils/meta/UniverseHelpers.scala
@@ -99,16 +99,7 @@ trait UniverseHelpers[U <: scala.reflect.api.Universe] {
       case DefDef(mods, name, tparams, vparams, tpt, rhs) => Some(mods, name, tparams, vparams, tpt, rhs)
     }
   }
-
-  object SequenceType {
-    val seqSym = typeOf[Seq[Any]].typeSymbol.asType
-
-    val scalaPackage = seqSym.owner.asType.toType
-
-    def apply(tpe: Type) = internal.typeRef(scalaPackage, seqSym, List(tpe))
-
-  }
-
+  
   object FunctionType { // TODO complete with all functions types!
     
     val Fun0Sym = typeOf[() => Any].typeSymbol.asType

--- a/src/main/scala/squid/ir/Lowering.scala
+++ b/src/main/scala/squid/ir/Lowering.scala
@@ -41,7 +41,29 @@ trait Lowering extends Transformer {
               val ruh = RuntimeUniverseHelpers
               val typ = r.typ.typeArgs.last // TODO be careful that a method implemented without parameter list can implement a method with an empty list (eg toString), which can make this crash
               base.rep(MethodApp(r, ruh.FunctionType.symbol(reps.size).toType member ruh.sru.TermName("apply") asMethod, Nil, Args(reps:_*)::Nil, typ))
-            case (r, args) => lastWords(s"Not supported yet: vararg $args") // TODO
+            case (r, ArgsVarargs(Args(reps @ _*), Args(vreps @ _*))) =>
+              val ruh = RuntimeUniverseHelpers
+              val functionArity = reps.size + vreps.size
+              val typ = r.typ.typeArgs.last
+              // transform repeated args into a Seq[typ].apply(vargs)
+              val varargsAsSeq = methodApp(
+                staticModule("scala.collection.Seq"),
+                loadMtdSymbol(
+                  loadTypSymbol("scala.collection.generic.GenericCompanion"),
+                  "apply",
+                  None),
+                typ :: Nil,
+                Args()(vreps: _*) :: Nil,
+                staticTypeApp(
+                  loadTypSymbol("scala.collection.Seq"),
+                  typ :: Nil)
+              )
+              base.rep(MethodApp(r, ruh.FunctionType.symbol(functionArity).toType member ruh.sru.TermName("apply") asMethod, Nil, Args((reps :+ varargsAsSeq):_* )::Nil, typ))
+            case (r, avs@ArgsVarargSpliced(Args(reps @ _*), vreps)) =>
+              val ruh = RuntimeUniverseHelpers
+              val typ = r.typ.typeArgs.last
+              val functionArity = reps.size + 1 // number arguments plus one Seq argument
+              base.rep(MethodApp(r, ruh.FunctionType.symbol(functionArity).toType member ruh.sru.TermName("apply") asMethod, Nil, Args((reps :+ vreps) :_*)::Nil, typ))
           }
           ascribe(res, retTyp) // We ascribe so that if the body is, e.g., `???`, we don't end up with ill-typed code. 
         case Left(Recursive) =>

--- a/src/test/scala/squid/classembed/ClassEmbeddingTests.scala
+++ b/src/test/scala/squid/classembed/ClassEmbeddingTests.scala
@@ -60,6 +60,15 @@ class ClassEmbeddingTests extends MyFunSuite {
     
     import MyClass._
     
+    // arg-vararg
+    code"""argVarargFoo("bar", 1, 2, 3) * 2""" transformWith Desugaring eqt
+      code"""((s: String, xs: Seq[Int]) => s.length + xs.sum + 1)("bar", Seq(1, 2, 3)) * 2"""
+
+    // arg-varargs spliced
+    code"""val args = Seq(1, 2, 3); argVarargFoo("bar", args:_*) * 2""" transformWith Desugaring eqt
+      code"""val args = Seq(1, 2, 3); ((s: String, xs: Seq[Int]) => s.length + xs.sum + 1)("bar", args) * 2"""
+
+    // varargs
     val ds = code"varargFoo(1, 2, 3) + 5" transformWith Desugaring
 
     ds eqt

--- a/src/test/scala/squid/classembed/ClassEmbeddingTests.scala
+++ b/src/test/scala/squid/classembed/ClassEmbeddingTests.scala
@@ -193,9 +193,10 @@ class ClassEmbeddingTests extends MyFunSuite {
     
     eqtBy(code"Vector.origin(3).arity", code"val v = Vector.origin(3); v.coords.length")(_ =~= _)
     
-    // TODO (vararg)
-    //println(ir"Vector.apply(1,2,3)")
-    //val Emb = Vector.EmbeddedIn(TestDSL2); println(Emb.Object.Defs.apply.value)
+    val Emb = Vector.EmbeddedIn(DSLBase)
+    eqtBy(Emb.Object.Defs.apply.value, code"(xs:Seq[Double]) => new Vector(List(xs:_*))")(_ =~= _)
+    
+    eqtBy(code"Vector.apply(1,2,3)", code"val vals = Seq(1.0,2.0,3.0); new Vector(List(vals:_*))")(_ =~= _)
     
   }
   

--- a/src/test/scala/squid/classembed/MyClass.scala
+++ b/src/test/scala/squid/classembed/MyClass.scala
@@ -56,7 +56,6 @@ object MyClass extends App with ir.SquidObject {
   def foo(x: Float): Float = x + 1
   def foo(x: String): String = x + 1
   def foo(x: Double): Double = x + 1
-
   
   @phase('Sugar)
   def recLol(x: Int): Int = if (x <= 0) 0 else recLol(x-1)+1

--- a/src/test/scala/squid/classembed/MyClass.scala
+++ b/src/test/scala/squid/classembed/MyClass.scala
@@ -29,8 +29,13 @@ class MyClass {
   def foo(x: Int) = baz + x
   def fooRef(x: Int) = this.foo(x)
   val baz = MyClass.swap(1,2)('lol)._2._2
-  
-  
+
+  @phase('Sugar)
+  def varargFoo(xs: Int*): Int = xs.sum + 1
+
+  @phase('Sugar)
+  def argVarargFoo(s: String, xs: Int*): Int = s.length + xs.sum + 1
+
   @overloadEncoding
   def lol(a: Int = 0, b: Int, c: String, d: String = "3"): String = a + b + c + d
   
@@ -40,10 +45,18 @@ object MyClass extends App with ir.SquidObject {
   
   @phase('Sugar)
   def foo(x: Int): Int = MyClass.foo(x.toLong).toInt
+
+  @phase('Sugar)
+  def varargFoo(xs: Int*): Int = xs.sum + 1
+
+  @phase('Sugar)
+  def argVarargFoo(s: String, xs: Int*): Int = s.length + xs.sum + 1
+
   def foo(x: Long): Long = x + 1
   def foo(x: Float): Float = x + 1
   def foo(x: String): String = x + 1
   def foo(x: Double): Double = x + 1
+
   
   @phase('Sugar)
   def recLol(x: Int): Int = if (x <= 0) 0 else recLol(x-1)+1
@@ -68,6 +81,10 @@ object MyClass extends App with ir.SquidObject {
 @embed
 object OrphanObject extends ir.SquidObject {
   def test[A](a: A) = (a,a)
+
+  def varargFoo(xs: Int*): Int = xs.sum + 1
+
+  def argVarargFoo(s: String, xs: Int*): Int = s.length + xs.sum + 1
 }
 
 


### PR DESCRIPTION
This is my first stab at adding vararg support in embedded defs.

My approach is to change the repeated parameters into a `Seq` for lambda application and then wrap the original parameters into `Seq.apply()` in the Lowering.

This does what I want in my usecase but I can't figure out how to write a test for it that does what I want (see inline note).

Also I am not sure about the last missing case for VarargsSpliced - what is the meaning of this?