### PR TITLE
Support cross-stage persistence (CSP)

### DIFF
--- a/bin/publishLocal.sh
+++ b/bin/publishLocal.sh
@@ -1,1 +1,1 @@
-sbt publishLocal core/publishLocal core_macros/publishLocal scBackend/publishLocal scBackendMacros/publishLocal
+sbt publishLocal core/publishLocal core_macros/publishLocal

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ lazy val commonSettings = Seq(
   organization := "ch.epfl.data",
   autoCompilerPlugins := true,
   scalacOptions ++= Seq("-feature", "-language:implicitConversions", "-language:higherKinds", "-language:postfixOps"
-    , "-deprecation"
+    , "-deprecation", "-unchecked"
   ),
   incOptions := incOptions.value.withLogRecompileOnMacro(false), // silences macro-related recompilation messages (cf. https://github.com/sbt/zinc/issues/142)
   resolvers += Resolver.sonatypeRepo("snapshots"),

--- a/core/src/main/scala/squid/ir/BaseInterpreter.scala
+++ b/core/src/main/scala/squid/ir/BaseInterpreter.scala
@@ -27,7 +27,7 @@ import scala.reflect.runtime.ScalaReflectSurgeon
 /**
   * TODO: a smarter version that creates the invokers and returns a _runner_ that can be ran more efficiently.
   */
-class BaseInterpreter extends Base with RuntimeSymbols with TraceDebug {
+class BaseInterpreter extends Base with CrossStageEnabled with RuntimeSymbols with TraceDebug {
   import BaseInterpreter._
   
   type TypSymbol = ScalaTypeSymbol
@@ -200,7 +200,8 @@ class BaseInterpreter extends Base with RuntimeSymbols with TraceDebug {
     
   }
   
-  
+  def crossStage(value: Any, trep: TypeRep): Rep = value
+  def extractCrossStage(r: Rep): Option[Any] = None
   
   
   def uninterpretedType[A: sru.TypeTag]: TypeRep = () => sru.typeOf[A].typeSymbol.asType

--- a/core/src/main/scala/squid/lang/Base.scala
+++ b/core/src/main/scala/squid/lang/Base.scala
@@ -64,7 +64,7 @@ trait Base extends TypingBase with quasi.QuasiBase {
     * Note: index should be None when the symbol is not overloaded, to allow for more efficient caching */
   def loadMtdSymbol(typ: TypSymbol, symName: String, index: Option[Int] = None, static: Boolean = false): MtdSymbol
   
-  /** High-level interface which implementation should specify how to construct (and potentially also deconstruct) constants */
+  /** High-level interface whose implementations should specify how to construct (and potentially also deconstruct) constants */
   trait ConstAPI {
     def apply[T: CodeType](v: T): Code[T,Any] = `internal Code`(const(v))
   }

--- a/core/src/main/scala/squid/lang/CrossStageEnabled.scala
+++ b/core/src/main/scala/squid/lang/CrossStageEnabled.scala
@@ -1,0 +1,38 @@
+// Copyright 2018 EPFL DATA Lab (data.epfl.ch)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package squid
+package lang
+
+import squid.quasi.DefaultQuasiConfig
+import squid.quasi.QuasiConfig
+
+trait CrossStageEnabled extends Base { base =>
+  
+  def crossStage(value: Any, trep: TypeRep): Rep
+  
+  // Note: this only really makes sense in an InspectableBase; but we can make it return None in other cases
+  def extractCrossStage(r: Rep): Option[Any]
+  
+  object CrossStage {
+    def apply[T: CodeType](v: T): Code[T,Any] = `internal Code`(crossStage(v, typeRepOf[T]))
+    def unapply[T](c: Code[T,_]): Option[T] = extractCrossStage(c.rep).asInstanceOf[Option[T]]
+  }
+  
+  trait CrossStageEnabledPredef[QC <: QuasiConfig] extends Predef[QC] {
+    val CrossStage = base.CrossStage
+  }
+  override val Predef = new Predef[DefaultQuasiConfig] with CrossStageEnabledPredef[DefaultQuasiConfig]
+  
+}

--- a/core/src/main/scala/squid/lang/IntermediateBase.scala
+++ b/core/src/main/scala/squid/lang/IntermediateBase.scala
@@ -168,5 +168,5 @@ trait IntermediateBase extends Base { ibase: IntermediateBase =>
 
 object IntermediateBase {
   import scala.tools.reflect.ToolBox
-  private lazy val toolBox = sru.runtimeMirror(getClass.getClassLoader).mkToolBox() // Q: necessary 'lazy'? (objects are already lazy)
+  private[squid] lazy val toolBox = sru.runtimeMirror(getClass.getClassLoader).mkToolBox() // Q: necessary 'lazy'? (objects are already lazy)
 }

--- a/core/src/main/scala/squid/quasi/MetaBases.scala
+++ b/core/src/main/scala/squid/quasi/MetaBases.scala
@@ -38,7 +38,7 @@ trait MetaBases {
     * are stored in the `symbols` mutable buffer.
     * Note: these are let-bound but not cached – caching is assumed to be performed by the caller (eg: ModularEmbedding).
     * @param baseType if defined, will be used to find potential static field accesses to the type/method symbols */
-  class MirrorBase(Base: Tree, baseType: Option[Type] = None) extends Base {
+  class MirrorBase(val Base: Tree, baseType: Option[Type] = None) extends Base {
     /* TODO: more clever let-binding so defs used once won't be bound? -- that would require changing `type Rep = Tree` to something like `type Rep = () => Tree` */
     import scala.collection.mutable
     

--- a/core/src/main/scala/squid/quasi/ModularEmbedding.scala
+++ b/core/src/main/scala/squid/quasi/ModularEmbedding.scala
@@ -456,7 +456,7 @@ class ModularEmbedding[U <: scala.reflect.api.Universe, B <: Base](val uni: U, v
     case _: DefDef =>
       throw EmbeddingException("Statement in expression position: "+x/*+(if (debug.debugOptionEnabled) s" [${x.getClass}]" else "")*/)
        
-    case _ if x.symbol.isMethod =>
+    case _ if x.symbol != null && x.symbol.isMethod =>
       throw EmbeddingException.Unsupported(s"Reference to local method `${x.symbol.name}`")
       
     case _ => throw EmbeddingException.Unsupported(""+x/*+(if (debug.debugOptionEnabled) s" [${x.getClass}]" else "")*/)

--- a/core/src/main/scala/squid/quasi/ModularEmbedding.scala
+++ b/core/src/main/scala/squid/quasi/ModularEmbedding.scala
@@ -212,7 +212,8 @@ class ModularEmbedding[U <: scala.reflect.api.Universe, B <: Base](val uni: U, v
         
       /** --- --- --- VARIABLE ASSIGNMENTS --- --- --- */
       case q"${vari @ Ident(_)} = $valu" =>  // Matching Ident because otherwise this can match a call to an update method!
-        val ref = readVal(ctx(vari.symbol.asTerm))
+        val ref = readVal(ctx.getOrElse(vari.symbol.asTerm, 
+          throw EmbeddingException.Unsupported(s"update to cross-stage mutable variable '$vari'")))
         val mtd = loadMtdSymbol(varTypSym, "$colon$eq", None)
         val retTp = liftType(Unit)
         methodApp(ref, mtd, Nil, Args(rec(valu, Some(vari.symbol.typeSignature)))::Nil, retTp)

--- a/core/src/main/scala/squid/quasi/QuasiEmbedder.scala
+++ b/core/src/main/scala/squid/quasi/QuasiEmbedder.scala
@@ -396,9 +396,14 @@ class QuasiEmbedder[C <: whitebox.Context](val c: C) {
               
             /** --- --- --- THIS REF --- --- --- */
             case This(tp) if !x.symbol.isModuleClass =>
+              /* // we used to convert `this` references to explicit free variables, which used to be fairly confusing/unexpected:
               // Note: Passing `x.symbol.asType.toType` will still result in a path-dependent module type because of hole coercion
               val tree = q"$baseTree.$$$$[${TypeTree(x.tpe)}](scala.Symbol.apply(${s"$tp.this"}))"
               liftTerm(tree, parent, expectedType)
+              */
+              requireCrossStageEnabled
+              val mb = b.asInstanceOf[(MetaBases{val u: c.universe.type})#MirrorBase with b.type]
+              q"${mb.Base}.crossStage($x, ${liftType(x.tpe).asInstanceOf[Tree]})".asInstanceOf[b.Rep]
               
               
             /** This is to find repeated holes: $-less references to holes that were introduced somewhere else.

--- a/core/src/main/scala/squid/quasi/QuasiMacros.scala
+++ b/core/src/main/scala/squid/quasi/QuasiMacros.scala
@@ -514,7 +514,7 @@ class QuasiMacros(val c: whitebox.Context) {
     
     val res = q"$myBaseTree.`internal CodeType`[$T]($codeTree)"
     
-    debug("Generated: "+res)
+    debug("Generated: "+showCode(res))
     //if (debug.debugOptionEnabled) debug("Of Type: "+c.typecheck(res).tpe) // Makes a StackOverflow when type evidence macro stuff happen
     
     //codeTree: c.Tree

--- a/core/src/main/scala/squid/utils/package.scala
+++ b/core/src/main/scala/squid/utils/package.scala
@@ -128,7 +128,7 @@ package object utils {
   def pairWith[A,B](f: A => B)(x: A) = x -> f(x)
   
   
-  implicit class SafeEq[T](val self: T) extends AnyVal {
+  implicit class SafeEq[T](private val self: T) extends AnyVal {
     def === (that: T) = self == that
     def =/= (that: T) = self != that
   }

--- a/core/src/main/scala/squid/utils/serial/package.scala
+++ b/core/src/main/scala/squid/utils/serial/package.scala
@@ -1,0 +1,29 @@
+package squid.utils
+
+package object serial {
+  // adapted from https://gist.github.com/laughedelic/634f1a1e5333d58085603fcff317f6b4
+  
+  import java.io._
+  import java.util.Base64
+  import java.nio.charset.StandardCharsets.UTF_8
+  
+  def serialize(value: Any): String = {
+    val stream: ByteArrayOutputStream = new ByteArrayOutputStream()
+    val oos = new ObjectOutputStream(stream)
+    oos.writeObject(value)
+    oos.close
+    new String(
+      Base64.getEncoder().encode(stream.toByteArray),
+      UTF_8
+    )
+  }
+  
+  def deserialize(str: String): Any = {
+    val bytes = Base64.getDecoder().decode(str.getBytes(UTF_8))
+    val ois = new ObjectInputStream(new ByteArrayInputStream(bytes))
+    val value = ois.readObject
+    ois.close
+    value
+  }
+  
+}

--- a/src/main/scala/squid/ir/ASTHelpers.scala
+++ b/src/main/scala/squid/ir/ASTHelpers.scala
@@ -44,7 +44,7 @@ trait ASTHelpers extends Base { self: AST =>
       case MethodApp(self, mtd, targs, argss, tp) =>
         rec(self)
         argss.foreach(_.reps foreach rec)
-      case Hole(_) | SplicedHole(_) | NewObject(_) | StaticModule(_) | Constant(_) | RecordGet(_,_,_) | _: BoundVal =>
+      case Hole(_) | SplicedHole(_) | NewObject(_) | StaticModule(_) | _:ConstantLike | RecordGet(_,_,_) | _: BoundVal =>
     }
   }
   
@@ -142,6 +142,8 @@ trait ASTHelpers extends Base { self: AST =>
       case Typed(h @ Hole(name), typ) => s"$$$name<:${typ |> apply}" + (if (showHoleInfo) 
         (h.originalSymbol map (os => s"(o=$os)") getOrElse "") + (h.matchedSymbol map (m => s"(m=$m)") getOrElse "") else "")
       case Typed(SplicedHole(name), typ) => s"$$$name<:${typ |> apply}*"
+      case CrossStageValue(value,typ) if showReturnTypes => s"<<$value:${typ |> apply}>>"
+      case CrossStageValue(value,typ)                    => s"<<$value>>"
     }
     def apply(typ: TypeRep) =
       typ.toString.replace("squid.ir.ScalaTyping.TypeHole[java.lang.String", "$[")

--- a/src/main/scala/squid/ir/ASTReinterpreter.scala
+++ b/src/main/scala/squid/ir/ASTReinterpreter.scala
@@ -20,6 +20,7 @@ import utils._
 import utils.meta.{RuntimeUniverseHelpers => ruh}
 import ruh.sru
 import squid.lang.Base
+import squid.lang.CrossStageEnabled
 
 import scala.collection.mutable
 
@@ -84,6 +85,12 @@ trait ASTReinterpreter { ast: AST =>
       case Ascribe(r,t) => newBase.ascribe(apply(r), rect(t))
       case h @ Hole(n) =>
         newBase.hole(n, rect(h.typ))
+      case h @ SplicedHole(n) =>
+        newBase.splicedHole(n, rect(h.typ))
+      case CrossStageValue(value,typ) => newBase match {
+        case nb: newBase.type with CrossStageEnabled => nb.crossStage(value, rect(typ).asInstanceOf[nb.TypeRep])
+        case _ => throw new IllegalArgumentException(s"Cannot reinterpret cross-stage value into non-cross-stage-enabled base $newBase")
+      }
         
       //case RecordGet(RepDef(bv), name, tp) =>
       //  //???

--- a/src/main/scala/squid/ir/CrossStageAST.scala
+++ b/src/main/scala/squid/ir/CrossStageAST.scala
@@ -1,4 +1,4 @@
-// Copyright 2017 EPFL DATA Lab (data.epfl.ch)
+// Copyright 2018 EPFL DATA Lab (data.epfl.ch)
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,20 +13,14 @@
 // limitations under the License.
 
 package squid
+package ir
 
-import lang._
-import quasi._
-import ir._
+import squid.utils._
+import squid.lang.CrossStageEnabled
 
-object MyBase extends SimpleAST with ClassEmbedder
-object TestDSL extends SimpleAST with ClassEmbedder
-object NormDSL extends SimpleAST with ClassEmbedder with OnlineOptimizer with BindingNormalizer //with BlockNormalizer
-object CrossStageDSL extends SimpleAST with ClassEmbedder with CrossStageAST
-
-object LegacyTestDSL extends SimpleAST with ClassEmbedder {
-  override val newExtractedBindersSemantics: Boolean = false
-}
-
-object Test {
-  object InnerTestDSL extends SimpleAST
+trait CrossStageAST extends AST with CrossStageEnabled {
+  
+  // make `crossStage` method public, officially enabling construction of cross-stage nodes
+  override def crossStage(value: Any, trep: TypeRep): Rep = super.crossStage(value, trep)
+  
 }

--- a/src/main/scala/squid/ir/SimpleEffects.scala
+++ b/src/main/scala/squid/ir/SimpleEffects.scala
@@ -96,7 +96,7 @@ trait SimpleEffects extends AST {
     case bv: BoundVal if !isTransparentType(bv.typ.typeSymbol.asType) => SimpleEffect.Latent
     case Ascribe(r,_) => r|>effectCached
     case Module(r,_,_) => r|>effectCached
-    case Constant(_) | _: BoundVal | StaticModule(_) | NewObject(_) | RecordGet(_,_,_) | _:Hole | _:SplicedHole => SimpleEffect.Pure
+    case _:ConstantLike | _: BoundVal | StaticModule(_) | NewObject(_) | RecordGet(_,_,_) | _:Hole | _:SplicedHole => SimpleEffect.Pure
   }
   
   

--- a/src/test/scala/squid/feature/CrossStageTests.scala
+++ b/src/test/scala/squid/feature/CrossStageTests.scala
@@ -1,0 +1,101 @@
+// Copyright 2018 EPFL DATA Lab (data.epfl.ch)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package squid
+package feature
+
+class CrossStageTests extends MyFunSuite(CrossStageDSL) {
+  import DSL.Predef._
+  
+  // TODO test ref to local val, local var, local method, local type?, val/var fields and methods, this ref
+  
+  test("Cross-Stage References to Primitive Types Yield Constants") {
+    
+    def const(v:Int) = code"v"
+    eqt(const(123), code"123")
+    eqt(const(123), Const(123))
+    eqt(CrossStage(123), Const(123))
+    same(const(123).run, 123)
+    
+    val a = 123
+    val p = code"a+1"
+    same(p.toString, """code"(123).+(1)"""")
+    
+  }
+  
+  test("MSP") {
+    
+    val v0 = Some(123)
+    val v1 = code"v0.get + 1"
+    same(v1.toString, """code"((cs_0: scala.Some[scala.Int]) => cs_0.get.+(1)) % (Some(123))"""")
+    val v2 = code"v1.compile + 1"
+    same(v2.compile, 125)
+    
+  }
+  
+  test("Matching") {
+    
+    val a = 123 // will be converted to a constant
+    
+    code"a + 1" match {
+      case code"(${CrossStage(n)}:Int)+1" => fail  // constants can no longer be interpreted as cross-stage values... could be confusing 
+      case code"(${Const(n)}:Int)+1" => same(n, 123)
+    }
+    
+    val s = 'test // not a primitive that can be converted to a constant
+    
+    same(code"s.name".compile, s.name)
+    
+    code"s.name" match {
+      case code"(${Const(sym)}:Symbol).name" => fail
+      case code"(${CrossStage(sym)}:Symbol).name" => same(sym, 'test)
+    }
+    
+    val ns = new{} // non-serializable object
+    assert(code"ns.toString".toString startsWith """code"((cs_0: java.lang.Object) => cs_0.toString()) % """)
+    assert(code"Some(ns)".compile.x eq ns)
+    
+  }
+  
+  test("Patterns Containing Cross-Stage Values") {
+    
+    val ls = List(1,2,3)
+    
+    code"ls.size" matches {
+      case code"ls.size" =>
+    } and {
+      case code"($l:List[Int]).size" =>
+        l eqt CrossStage(ls)
+    }
+    
+    def foo(lspat: List[Int], cde: ClosedCode[Int]) = cde match {
+      case code"lspat.size" => true
+      case _ => false
+    }
+    assert(foo(List(1,2,3), code"ls.size")) // this should not cache the pattern in `foo` (with lspat=List(1,2,3))
+    //assert(!foo(List(1,2), code"ls.size")) // FIXME: disable caching of patterns when they include a CSV!
+    
+  }
+  
+  test("No Cross-Stage References Unless Allowed") {
+    import TestDSL.Predef._
+    
+    val ls = List(1,2,3)
+    assertDoesNotCompile(""" code"ls.size" """)
+    // ^ Error:(77, 5) Embedding Error: Cannot use cross-stage reference: base TestDSL.Predef.base does not extend squid.lang.CrossStageEnabled.
+    
+  }
+  
+  
+}

--- a/src/test/scala/squid/feature/CrossStageTests.scala
+++ b/src/test/scala/squid/feature/CrossStageTests.scala
@@ -98,4 +98,17 @@ class CrossStageTests extends MyFunSuite(CrossStageDSL) {
   }
   
   
+  test("Serialization of Cross-Stage Values") {
+    
+    val ls = List(1,2,3)
+    val cde = code"ls.map(_+1).sum"
+    
+    val tree = base.scalaTree(cde.rep)
+    assert(tree.toString ==
+      """_root_.squid.utils.serial.deserialize("rO0ABXNyADJzY2FsYS5jb2xsZWN0aW9uLmltbXV0YWJsZS5MaXN0JFNlcmlhbGl6YXRpb25Qcm94eQAAAAAAAAABAwAAeHBzcgARamF2YS5sYW5nLkludGVnZXIS4qCk94GHOAIAAUkABXZhbHVleHIAEGphdmEubGFuZy5OdW1iZXKGrJUdC5TgiwIAAHhwAAAAAXNxAH4AAgAAAAJzcQB+AAIAAAADc3IALHNjYWxhLmNvbGxlY3Rpb24uaW1tdXRhYmxlLkxpc3RTZXJpYWxpemVFbmQkilxjW/dTC20CAAB4cHg=").asInstanceOf[scala.collection.immutable.List[scala.Int]].map[scala.Int, scala.collection.immutable.List[scala.Int]](((x$1_0: scala.Int) => x$1_0.$plus(1)))(scala.collection.immutable.List.canBuildFrom[scala.Int]).sum[scala.Int](scala.math.Numeric.IntIsIntegral)""")
+    
+    same(squid.lang.IntermediateBase.toolBox.eval(tree), 2 + 3 + 4)
+    
+  }
+  
 }

--- a/src/test/scala/squid/feature/CrossStageTests.scala
+++ b/src/test/scala/squid/feature/CrossStageTests.scala
@@ -84,7 +84,7 @@ class CrossStageTests extends MyFunSuite(CrossStageDSL) {
       case _ => false
     }
     assert(foo(List(1,2,3), code"ls.size")) // this should not cache the pattern in `foo` (with lspat=List(1,2,3))
-    //assert(!foo(List(1,2), code"ls.size")) // FIXME: disable caching of patterns when they include a CSV!
+    assert(!foo(List(1,2), code"ls.size"))  // caching of patterns when they include a CSV is disabled
     
   }
   


### PR DESCRIPTION
Cross-stage persistence is the ability for code fragments to refer to values created at a previous stages, as in `val foo = 'ok; code"Some(foo.name)"` – notice the bare reference to `foo`, which is not an inserted piece of code, but really the value `'ok`.

This capability is extremely useful when doing runtime multi-stage programming.  For instance, imagine that you are making a data manager class `DataManager` that uses multi-stage programming (i.e., runtime code generation, composition, and compilation) to speed-up some of its operations. It could look like:

```scala
abstract class DataManager {
  val data: Array[Int]
  def iterator = data.iterator
  def stagedIterator = code"data.iterator"
}
```

Using `myDataManager.stagedIterator`, one can obtain a _closed_ piece of code (of type `Code[Iterator[Int],{}]`) that can be inserted into a bigger program and optimized, and then runtime-compiled –– the generated bytecode will have a runtime reference to `myDataManager.data`.

The feature does _not_ make sense for _compile-time multi-stage programming_ or _static code generation_. I had previously shied away from supporting CSP because of the unclear behavior in this case. Squid now solves it in two ways:

 * cross-stage persistence is only enabled if the `Base` extends `CrossStageEnabled`, which prevents users from using CSP by mistake;

 * if CSP is enabled and one tries to generate static Scala code (as opposed to runtime-compiling it), then Java serialization is used on a best-effort basis to convert cross-stage values to a string representation to be loaded when the generated program is ran;
for example in `val ls = List(1,2,3); val cde = code"ls.map(_+1).sum"`, `cde` contains a cross-stage reference to a `List(1,2,3)`. Trying to generate static Scala code from it with `base.scalaTree(cde.rep)` [results in](https://github.com/epfldata/squid/blob/cross-stage-persistence/src/test/scala/squid/feature/CrossStageTests.scala#L144-L154):

```scala
_root_.squid.utils.serial.deserialize(
  "rO0ABXNyADJzY2FsYS5jb2xsZWN0aW9uLmltbXV0YWJsZS5MaXN0JFNlcmlhbGl6YXRpb25Qcm94eQAAAAAAAAABAwAAeHBzcgARamF2YS5sYW5nLkludGVnZXIS4qCk94GHOAIAAUkABXZhbHVleHIAEGphdmEubGFuZy5OdW1iZXKGrJUdC5TgiwIAAHhwAAAAAXNxAH4AAgAAAAJzcQB+AAIAAAADc3IALHNjYWxhLmNvbGxlY3Rpb24uaW1tdXRhYmxlLkxpc3RTZXJpYWxpemVFbmQkilxjW/dTC20CAAB4cHg="
).asInstanceOf[scala.collection.immutable.List[scala.Int]]
 .map[scala.Int, scala.collection.immutable.List[scala.Int]](((x$1_0: scala.Int) => x$1_0.$plus(1)))(scala.collection.immutable.List.canBuildFrom[scala.Int])
 .sum[scala.Int](scala.math.Numeric.IntIsIntegral)
```