### PR TITLE
Support Scala 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,13 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+val scala211Version = "2.11.11"
+val scala212Version = "2.12.5"
+
 val paradiseVersion = "2.1.0"
 val squidVersion = "0.3.0-SNAPSHOT"
 val squidIsSnapshot: Boolean = squidVersion endsWith "-SNAPSHOT"
 
 lazy val commonSettings = Seq(
   version := squidVersion,
-  scalaVersion := "2.11.11",
+  scalaVersion := scala212Version, // default Scala version
+  crossScalaVersions := Seq(scala211Version, scala212Version),
   organization := "ch.epfl.data",
   autoCompilerPlugins := true,
   scalacOptions ++= Seq("-feature", "-language:implicitConversions", "-language:higherKinds", "-language:postfixOps"
@@ -27,25 +31,19 @@ lazy val commonSettings = Seq(
   incOptions := incOptions.value.withLogRecompileOnMacro(false), // silences macro-related recompilation messages (cf. https://github.com/sbt/zinc/issues/142)
   resolvers += Resolver.sonatypeRepo("snapshots"),
   resolvers += Resolver.sonatypeRepo("releases"),
-  addCompilerPlugin("org.scalamacros" % "paradise" % paradiseVersion cross CrossVersion.full),
-  libraryDependencies ++= Seq(
-    "junit" % "junit-dep" % "4.10" % "test",
-    "org.scalatest" % "scalatest_2.11" % "2.2.0" % "test"
-  ),
-  libraryDependencies ++= (
-      if (scalaVersion.value.startsWith("2.10")) List("org.scalamacros" %% "quasiquotes" % paradiseVersion)
-      else Nil
-    ),
-  libraryDependencies += "com.lihaoyi" % "ammonite" % "1.0.3" % "test" cross CrossVersion.full,
-  // For the ammonite REPL:
-  sourceGenerators in Test += Def.task {
-    val file = (sourceManaged in Test).value / "amm.scala"
-    IO.write(file, """object amm extends App { ammonite.Main().run() }""")
-    Seq(file)
-  }.taskValue
+  addCompilerPlugin("org.scalamacros" % "paradise" % paradiseVersion cross CrossVersion.full)
+, libraryDependencies += "org.scalactic" %% "scalactic" % "3.0.5"
+, libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5" % "test"
+  
+//, libraryDependencies += "com.lihaoyi" % "ammonite" % "1.0.3" % "test" cross CrossVersion.full
+//  // For the ammonite REPL:
+//, sourceGenerators in Test += Def.task {
+//    val file = (sourceManaged in Test).value / "amm.scala"
+//    IO.write(file, """object amm extends App { ammonite.Main().run() }""")
+//    Seq(file)
+//  }.taskValue
+  
 ) ++ publishSettings
-lazy val scalaReflect = Def.setting { "org.scala-lang" % "scala-reflect" % scalaVersion.value }
-lazy val scalaCompiler = Def.setting { "org.scala-lang" % "scala-compiler" % scalaVersion.value }
 
 lazy val main = (project in file(".")).
   dependsOn(core).
@@ -60,9 +58,6 @@ lazy val core = (project in file("core")).
   settings(commonSettings: _*).
   settings(
     name := "squid-core",
-    libraryDependencies += scalaReflect.value,
-    libraryDependencies += scalaCompiler.value,
-    // other settings here
     //libraryDependencies += "ch.epfl.lamp" % "scala-yinyang_2.11" % "0.2.0-SNAPSHOT",
     libraryDependencies += scalaVersion("org.scala-lang" % "scala-reflect" % _).value,
     libraryDependencies += scalaVersion("org.scala-lang" % "scala-library" % _).value,
@@ -116,7 +111,6 @@ val developers =
       </developers>
 
 lazy val publishSettings = Seq(
-  // resolvers += Resolver.sonatypeRepo("releases"),
   publishMavenStyle := true,
   isSnapshot := squidIsSnapshot,
   publishTo := {

--- a/core/src/main/scala/squid/ir/EmbeddedClass.scala
+++ b/core/src/main/scala/squid/ir/EmbeddedClass.scala
@@ -29,8 +29,11 @@ abstract class EmbeddedClass[B <: Base](val base: B) {
   
   def mtd(sym: Mtd) = defs get sym
   
+  // Stopped working in 2.12: overriding value Class in class EmbeddedClass of type AnyRef{val Defs: Any};
+  /*
   val Object: { val Defs: Any }
   val Class: { val Defs: Any }
+  */
   
 }
 

--- a/core/src/main/scala/squid/lang/IntermediateBase.scala
+++ b/core/src/main/scala/squid/lang/IntermediateBase.scala
@@ -119,6 +119,8 @@ trait IntermediateBase extends Base { ibase: IntermediateBase =>
     /** Executes the code at runtime using Java reflection */
     def run(implicit ev: {} <:< Ctx): Typ = {
       val Inter = new ir.BaseInterpreter
+      // ^ Note: making a new one each time is wasteful, but because it extends RuntimeSymbols, which has mutable
+      //         caches, the BaseInterpreter is not thread-safe... (and Squid tests are ran in parallel)
       reinterpret(self.rep, Inter)().asInstanceOf[Typ]
     }
     

--- a/core/src/main/scala/squid/quasi/QuasiEmbedder.scala
+++ b/core/src/main/scala/squid/quasi/QuasiEmbedder.scala
@@ -337,7 +337,7 @@ class QuasiEmbedder[C <: whitebox.Context](val c: C) {
     def bindScope[R](scps: List[TermSymbol->Type])(k: => R) = {
       val old = boundScopes
       boundScopes ++= scps
-      k alsoDo (boundScopes = old)
+      k alsoDo {boundScopes = old}
     }
     
     def freshSingletonVariableType(nam: TermName, typ: Type) = {

--- a/core/src/main/scala/squid/quasi/QuasiMacros.scala
+++ b/core/src/main/scala/squid/quasi/QuasiMacros.scala
@@ -574,7 +574,10 @@ class QuasiMacros(val c: whitebox.Context) {
     val name -> term = s match {
       case q"scala.this.Predef.ArrowAssoc[$_](scala.Symbol.apply(${Literal(Constant(name: String))})).->[$_]($term)" =>
         name -> term
-      case _ => c.abort(s.pos, "Illegal syntax for `subs`; Expected: `term0.subs 'name -> term1`")
+      // In Scala 2.12, we don't get the weird `this` anymore:
+      case q"scala.Predef.ArrowAssoc[$_](scala.Symbol.apply(${Literal(Constant(name: String))})).->[$_]($term)" =>
+        name -> term
+      case _ => c.abort(s.pos, s"Illegal syntax for `subs`; Expected: `term0.subs 'name -> term1`, found: `${showCode(s)}`")
     }
     
     //debug(name, term)

--- a/core/src/main/scala/squid/utils/meta/UniverseHelpers.scala
+++ b/core/src/main/scala/squid/utils/meta/UniverseHelpers.scala
@@ -159,16 +159,33 @@ trait UniverseHelpers[U <: scala.reflect.api.Universe] {
   }
   
   def transformer(rec_pf: (Tree => Tree) => PartialFunction[Tree, Tree]) = {
+    // Scala 2.12 bug reported there: https://github.com/scala/bug/issues/10856
+    /*
     new Transformer {
-      val pf: PartialFunction[Tree, Tree] = rec_pf(transform)
+      val pf: PartialFunction[Tree, Tree] = rec_pf(transform) // on Scala 2.12, this raises: java.lang.NoSuchMethodError: squid.utils.meta.UniverseHelpers$$anon$5.pf()Lscala/PartialFunction
+      // ^ solved if we make it a def
       override def transform(x: Tree) = pf.applyOrElse(x, super.transform)
     } transform _
+    */
+    val t = new Transformer {
+      val pf: PartialFunction[Tree, Tree] = rec_pf(transform)
+      override def transform(x: Tree) = pf.applyOrElse(x, super.transform)
+    }
+    t transform _
   }
   def analyser(rec_pf: (Tree => Unit) => PartialFunction[Tree, Unit]) = {
+    // cf Scala 2.12 bug:
+    /*
     new Traverser {
       val pf: PartialFunction[Tree, Unit] = rec_pf(traverse)
       override def traverse(x: Tree) = pf.applyOrElse(x, super.traverse)
     } traverse _
+    */
+    val t = new Traverser {
+      val pf: PartialFunction[Tree, Unit] = rec_pf(traverse)
+      override def traverse(x: Tree) = pf.applyOrElse(x, super.traverse)
+    }
+    t traverse _
   }
   
   

--- a/core/src/main/scala/squid/utils/package.scala
+++ b/core/src/main/scala/squid/utils/package.scala
@@ -162,5 +162,9 @@ package object utils {
   /** Used to make Scala unexhaustivity warnings believed to be spurious go away */
   def spuriousWarning = lastWords("Case was reached that was thought to be unreachable.")
   
+  def checkless[A,B](pf: PartialFunction[A,B]): A => B = pf
+  
+  /** Used when we don't want Scalac to assume that something is true (e.g., pattern guard). */
+  @inline def trueButDontTellPlz: Bool = true
   
 }

--- a/core_macros/src/main/scala/BaseInterpreterMacros.scala
+++ b/core_macros/src/main/scala/BaseInterpreterMacros.scala
@@ -34,6 +34,16 @@ object BaseInterpreterMacros {
           (pq"$v", q"val $p: Any", q"$v.value = $p")
         }).unzip3
         cq"List(..${vars}) => (..$params) => {..$assigns; body}"
+        /* ^ In Scala 2.12, lambdas are encoded as a special class that Scala's runtime reflection does not seem to be
+             able to recognize and load, making it crash with an assertion error;
+             we can still create old-fashioned instances of FunctionN using the `new` syntax as below, but this is not a
+             general solution, as lambdas could come from any place in the application, not just from the `lambda`
+             factory. */
+        //cq"""List(..${vars}) =>
+        //  new _root_.scala.${TypeName("Function"+i)}[..${(0 to i).map(_ => tq"Any")}] {
+        //    def apply(..$params) = {..$assigns; body}
+        //  }
+        //"""
       }
     }}"
     //println(result)

--- a/src/main/scala/squid/ir/ASTHelpers.scala
+++ b/src/main/scala/squid/ir/ASTHelpers.scala
@@ -33,7 +33,7 @@ trait ASTHelpers extends Base { self: AST =>
     case RepDef(Hole(_)|SplicedHole(_)) => return true
   } thenReturn false
   
-  def traversePartial(f: PartialFunction[Rep, Boolean]) = traverse(f orElse PartialFunction(_ => true)) _
+  def traversePartial(f: PartialFunction[Rep, Boolean]) = traverse(f orElse { case _ => true }) _
   
   def traverse(f: Rep => Boolean)(r: Rep): Unit = {
     val rec = if (f(r)) traverse(f) _ else ignore

--- a/src/test/scala/squid/feature/BasicEmbedding.scala
+++ b/src/test/scala/squid/feature/BasicEmbedding.scala
@@ -141,22 +141,22 @@ class BasicEmbedding extends MyFunSuite {
   }
   
   test("Methods") {
-    import collection.mutable.Stack
+    import collection.mutable.ArrayBuffer
     
-    code"Stack[Int](1,42,2).push(0)" matches {
-      case code"Stack(1,$n,2).push($m)" =>
+    code"ArrayBuffer[Int](1,42,2).+=(0)" matches {
+      case code"ArrayBuffer(1,$n,2).+=($m)" =>
         n eqt code"42"
         m eqt code"0"
     }
     
-    code"Stack(42).map(_+1)" matches {
-      case code"Stack[$ta]($n).map($f: ta => $tb)" => eqt(f.trep, typeRepOf[Int => Int])
+    code"ArrayBuffer(42).map(_+1)" matches {
+      case code"ArrayBuffer[$ta]($n).map($f: ta => $tb)" => eqt(f.trep, typeRepOf[Int => Int])
     }
     
-    code"Stack[Int](42).map(_+1).isEmpty" matches {
-      case code"Stack[Int](42).map(_+1).isEmpty" => // TODO
+    code"ArrayBuffer[Int](42).map(_+1).isEmpty" matches {
+      case code"ArrayBuffer[Int](42).map(_+1).isEmpty" => // TODO
     } and {
-      case code"Stack[$ta]($n).map($f: ta => $tb).isEmpty" =>
+      case code"ArrayBuffer[$ta]($n).map($f: ta => $tb).isEmpty" =>
         eqt(ta.rep, typeRepOf[Int])
         eqt(tb.rep, typeRepOf[Int])
         eqt(f.Typ.rep, typeRepOf[Int => Int])

--- a/src/test/scala/squid/feature/CrossStageTests.scala
+++ b/src/test/scala/squid/feature/CrossStageTests.scala
@@ -105,7 +105,7 @@ class CrossStageTests extends MyFunSuite(CrossStageDSL) {
     
     val ns = new{} // non-serializable object
     assert(code"ns.toString".toString startsWith """code"((cs_0: java.lang.Object) => cs_0.toString()) % """)
-    assert(code"Some(ns)".compile.x eq ns)
+    assert(code"Some(ns)".compile.get eq ns)
     
   }
   

--- a/src/test/scala/squid/feature/VariableSymbolTests.scala
+++ b/src/test/scala/squid/feature/VariableSymbolTests.scala
@@ -337,7 +337,7 @@ class VariableSymbolTests extends MyFunSuite {
     
     val p = code"val a = 1; val b = 2; val c = 3; a + b + c"
     
-    val Succeeded = ()
+    def Succeeded = ()
     // ^ Since Scala 2.12.5, I got errors from the `assertDoesNotCompile` below, due to Scalatest emitting a
     //   non-qualifiedreference to org.scalatest.Succeeded.type by way of `reify { Succeeded }`; this is a problem
     //   because the `rewrite` macro untypechecks the body of match cases and removes symbols attached to identifiers.

--- a/src/test/scala/squid/feature/VariableSymbolTests.scala
+++ b/src/test/scala/squid/feature/VariableSymbolTests.scala
@@ -337,6 +337,12 @@ class VariableSymbolTests extends MyFunSuite {
     
     val p = code"val a = 1; val b = 2; val c = 3; a + b + c"
     
+    val Succeeded = ()
+    // ^ Since Scala 2.12.5, I got errors from the `assertDoesNotCompile` below, due to Scalatest emitting a
+    //   non-qualifiedreference to org.scalatest.Succeeded.type by way of `reify { Succeeded }`; this is a problem
+    //   because the `rewrite` macro untypechecks the body of match cases and removes symbols attached to identifiers.
+    //   No idea why this was not triggered in Scala 2.11...
+    
     p rewrite {
       case code"val $v: $vt = $init; $body:$bt" =>
         val w = Variable[MutVar[vt.Typ]]()
@@ -358,8 +364,7 @@ class VariableSymbolTests extends MyFunSuite {
       
     }
     
-     p transformWith R eqt code"var a = 1; var b = 2; var c = 3; a + b + c"
-    
+    p transformWith R eqt code"var a = 1; var b = 2; var c = 3; a + b + c"
     
   }
   


### PR DESCRIPTION
The main difficulties in porting the code base to 2.12 were:

 * two compiler bugs introduced by Scala 2.12, reported at:

    - https://github.com/scala/bug/issues/10856

    - https://github.com/scala/bug/issues/10857

 * the limitations of Scala runtime reflection with respect to the new encoding of function values (Java 8 lambdas), which affected Squid’s reflection-based interpreter

 * a subtle change in the behavior of Scala’s reify{} used by Scalatest, which produced an extruded variable when used inside invocations of Squid’s rewrite macro

 * solving some new Scala 2.12 warnings in macro-generated code