### PR TITLE
New feature: variable function insertion

### DIFF
--- a/core/src/main/scala/squid/quasi/QuasiBase.scala
+++ b/core/src/main/scala/squid/quasi/QuasiBase.scala
@@ -431,9 +431,13 @@ self: Base =>
   @compileTimeOnly("Unquote syntax ${...} cannot be used outside of a quasiquote.")
   def $$_*[T](name: Symbol): Seq[T] = ???
   
+  /* Used by QuasiMacro when inserting a Variable directly into a code fragment. */
   @compileTimeOnly("This method is not supposed to be used manually.")
   def $$_var[T](v: Variable[T]): T = ???
   
+  /* Used by QuasiMacro when inserting a Variable function into a code fragment. */
+  @compileTimeOnly("This method is not supposed to be used manually.")
+  def $$_varFun[V,T,C](refIdent: V)(vf: Variable[V] => OpenCode[T]): T = ???
   
   // note: the following functions are implicitly inserted by QuasiEmbedder,
   //       so that code"$f(...)" is equivalent to code"${liftOpenFun(f)}(...)"

--- a/core/src/main/scala/squid/quasi/QuasiEmbedder.scala
+++ b/core/src/main/scala/squid/quasi/QuasiEmbedder.scala
@@ -58,7 +58,6 @@ class QuasiEmbedder[C <: blackbox.Context](val c: C) {
   val scal = q"_root_.scala"
   
   
-  lazy val VariableCtxSym = symbolOf[QuasiBase#Variable[Any]#Ctx]
   def variableContext(tree: Tree) = {
     val singt = singletonTypeOf(tree).getOrElse(throw QuasiException(
       s"Cannot use variable of non-singleton type ${tree.tpe}",
@@ -516,10 +515,6 @@ class QuasiEmbedder[C <: blackbox.Context](val c: C) {
               if (!boundScopes.valuesIterator.exists(_ =:= ctx)) termScope ::= ctx
               q"$v.rep".asInstanceOf[b.Rep]
               
-              
-            case q"$baseTree.$$Code[$tpt]($idt)" =>
-              val tree = q"$baseTree.$$[$tpt,$Any]($idt.unsafe_asClosedCode)"
-              liftTerm(tree, parent, expectedType)
               
             /** Replaces insertion unquotes with whatever `insert` feels like inserting.
               * In the default quasi config case, this will be the trees representing the inserted elements. */

--- a/core/src/main/scala/squid/quasi/QuasiEmbedder.scala
+++ b/core/src/main/scala/squid/quasi/QuasiEmbedder.scala
@@ -516,7 +516,9 @@ class QuasiEmbedder[C <: blackbox.Context](val c: C) {
               q"$v.rep".asInstanceOf[b.Rep]
               
             case q"$baseTree.$$$$_varFun[$vtp,$tpt,$ctxt]($vref)($repfun)" =>
-              val bv = ctx.get(vref.symbol.asTerm).get // TODO b/e
+              val bv = ctx.get(vref.symbol.asTerm).getOrElse(throw QuasiException(
+                s"Inserted variable function refers to a variable '${showCode(vref)}' that is not bound in the scope of that quote.",
+                Some(repfun.pos)))
               val mb = b.asInstanceOf[(MetaBases{val u: c.universe.type})#MirrorBase with b.type]
               val tree = q"$baseTree.$$[$tpt,$ctxt]($repfun($Base.Variable.fromBound(${bv.asInstanceOf[mb.BoundVal].tree})))"
               liftTerm(tree, parent, expectedType)

--- a/core/src/main/scala/squid/quasi/QuasiEmbedder.scala
+++ b/core/src/main/scala/squid/quasi/QuasiEmbedder.scala
@@ -515,6 +515,11 @@ class QuasiEmbedder[C <: blackbox.Context](val c: C) {
               if (!boundScopes.valuesIterator.exists(_ =:= ctx)) termScope ::= ctx
               q"$v.rep".asInstanceOf[b.Rep]
               
+            case q"$baseTree.$$$$_varFun[$vtp,$tpt,$ctxt]($vref)($repfun)" =>
+              val bv = ctx.get(vref.symbol.asTerm).get // TODO b/e
+              val mb = b.asInstanceOf[(MetaBases{val u: c.universe.type})#MirrorBase with b.type]
+              val tree = q"$baseTree.$$[$tpt,$ctxt]($repfun($Base.Variable.fromBound(${bv.asInstanceOf[mb.BoundVal].tree})))"
+              liftTerm(tree, parent, expectedType)
               
             /** Replaces insertion unquotes with whatever `insert` feels like inserting.
               * In the default quasi config case, this will be the trees representing the inserted elements. */

--- a/core/src/main/scala/squid/quasi/QuasiMacros.scala
+++ b/core/src/main/scala/squid/quasi/QuasiMacros.scala
@@ -331,6 +331,7 @@ class QuasiBlackboxMacros(val c: blackbox.Context) {
               case AsFun3(AsCode(t0,ctx0), AsCode(t1,ctx1), AsCode(t2,ctx2), AsCode(tr,ctxr)) =>
                 checkIsBottom(ctx0); checkIsBottom(ctx1); checkIsBottom(ctx2)
                 q"$base.$$[($t0,$t1,$t2)=>$tr,$ctxr]($base.liftOpenFun3[$t0,$t1,$t2,$tr]($t))"
+                
               case AsVariableFun(varTyp,existSyms,retTyp,retCtx) =>
                 debug(s"Insertion of variable function with",varTyp,existSyms,retTyp,retCtx)
                 t match {
@@ -361,6 +362,9 @@ class QuasiBlackboxMacros(val c: blackbox.Context) {
                     q"$base.$$$$_varFun[$varTyp,$retTyp,$ctx](${x.name})($t0)"
                   case _ => throw QuasiException("Inserted variable functions must be lambda expressions.", Some(t.pos))
                 }
+              case AsFun2(AsVariable(_),AsVariable(_), _) | AsFun3(AsVariable(_),AsVariable(_),AsVariable(_), _) =>
+                throw QuasiException("Inserted variable functions are currently only supported for function arity 1.", Some(t.pos))
+                
               case _ => 
                 debug(s"Unrecognized insertion of type '${t.tpe}': ${t}\n –– typing may be imprecise as a result.")
                 q"$base.$$($t)"

--- a/core/src/main/scala/squid/quasi/QuasiMacros.scala
+++ b/core/src/main/scala/squid/quasi/QuasiMacros.scala
@@ -168,6 +168,7 @@ class QuasiBlackboxMacros(val c: blackbox.Context) {
   lazy val CodeSym = symbolOf[QuasiBase#Code[_,_]]
   lazy val AnyCodeSym = symbolOf[QuasiBase#AnyCode[_]]
   lazy val VariableSym = symbolOf[QuasiBase#Variable[_]]
+  //lazy val VariableCtxSym = symbolOf[QuasiBase#Variable[Any]#Ctx] // doesn't seem to work!! – prints "free type Ctx"
   
   // TODO generalize to handle AnyCode and retrieve the path-dependent context type... (if well-defined/not existential!)
   def asCode(tp: Type, typeOfBase: Type) = tp.baseType(CodeSym) |>? {

--- a/src/test/scala/squid/feature/CrossQuotationVariableFunctions.scala
+++ b/src/test/scala/squid/feature/CrossQuotationVariableFunctions.scala
@@ -1,0 +1,82 @@
+// Copyright 2018 EPFL DATA Lab (data.epfl.ch)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package squid
+package feature
+
+import squid.ir.BottomUpTransformer
+import squid.ir.SimpleRuleBasedTransformer
+import squid.utils._
+
+class CrossQuotationVariableFunctions extends MyFunSuite {
+  import DSL.Predef._
+  import DSL.Quasicodes._
+  
+  def foo[C](cde: Code[Int,C]) = code"$cde + 1"
+  
+  test("Basics") {
+    
+    val model = code"val x = 0; (x+1) * 2"
+    
+    val res = code"val v = 0; ${(v:Variable[Int]) => foo(v.toCode)} * 2"
+    res eqt model
+    assert(res.run == 2) // res is closed!
+    
+    code"val v = 0; ${(v:Variable[Int]) => code"$v + 1"} * 2" eqt model
+    
+    //code"val v = 0; ${(v:Variable[Int]) => foo(code"42")} * 2" eqt code"val x = 0; (${code"42"}+1) * 2"
+    // ^ FIXME
+    
+  }
+  
+  test("Erroneous uses") {
+    
+    val x = 123
+    
+    assertDoesNotCompile("""
+      code"val v = 0; ${(x:Variable[Int]) => x.toCode} * 2"
+    """)
+    // ^ TODO B/E
+    
+    assertDoesNotCompile("""
+      code"val v = 0; ${(y:Variable[Int]) => y.toCode} * 2"
+    """) // Embedding Error: Quoted expression does not type check: not found: value y
+    
+    val fun = (v:Variable[Int]) => foo(v.toCode)
+    assertDoesNotCompile("""
+      code"val v = 0; ${fun} * 2"
+    """)
+    // ^ TODO B/E
+    
+    val v = Variable[Int]
+    val cde = code"$v+1" // contains context of wrong variable!
+    //code"val v = 0; ${(v:Variable[Int]) => cde} * 2" alsoApply println
+    // ^ FIXME
+    
+    import scala.language.existentials
+    val cde2 = { val v = Variable[Int]; code"$v+1" } // contains context of wrong variable, as existential!
+    //code"val v = 0; ${(v:Variable[Int]) => cde} * 2" alsoApply println
+    // ^ FIXME
+    
+  }
+  
+  test("Arities 2 and 3") {
+    
+    // TODO
+    
+    // TODO test error on arity 4
+    
+  }
+  
+}

--- a/src/test/scala/squid/feature/CrossQuotationVariableFunctions.scala
+++ b/src/test/scala/squid/feature/CrossQuotationVariableFunctions.scala
@@ -81,9 +81,15 @@ class CrossQuotationVariableFunctions extends MyFunSuite {
   
   test("Arities 2 and 3") {
     
-    // TODO
+    // TODO: support arities 2 and 3
     
-    // TODO test error on arity 4
+    //code"val v = 0; val w = 1; ${(v:Variable[Int], w:Variable[Int]) => foo(code"$v + $w")} * 2"
+    // ^ Error:(85, 69) Quasiquote Error: Inserted variable functions are currently only supported for function arity 1.
+    
+    assertDoesNotCompile("""
+      code"val v_0 = 0; val v_1 = 1; val v_2 = 2; val v_3 = 3; ${
+        (v_0:Variable[Int],v_1:Variable[Int],v_2:Variable[Int],v_3:Variable[Int]) => code"42"} * 2"
+    """) // Error:(89, 5) Embedding Error: Quoted expression does not type check: overloaded method value $ with alternatives: [...]
     
   }
   

--- a/src/test/scala/squid/functional/StagingPower.scala
+++ b/src/test/scala/squid/functional/StagingPower.scala
@@ -35,17 +35,31 @@ class StagingPower extends MyFunSuite {
     
   }
   
+  val model = code"(y: Double) => y * (y * (y * 1.0))"
+  
   test("x => power(3)(x)") {
     
     val p3f = code"(x: Double) => ${power(3)(code"?x:Double")}" // TODO look at what this generates...
     
     assert(p3f =~= code"(x: Double) => x * (x * (x * 1.0))")
-    assert(p3f =~= code"(y: Double) => y * (y * (y * 1.0))")
+    assert(p3f =~= model)
     
     assert((p3f.run apply 2) == 8)
     
   }
   
+  def power2[C](n: Int)(v: Variable[Double]): Code[Double,v.Ctx] =
+    if (n == 0) code"1.0" else code"$v * ${power2(n-1)(v)}"
+  
+  test("power(3)(x) alternative") {
+    
+    val p3f = code"(x: Double) => ${(x: Variable[Double]) => power(3)(x.toCode)}"
+    p3f eqt model
+    
+    val p3f2 = code"(x: Double) => ${(x: Variable[Double]) => power2(3)(x)}"
+    p3f2 eqt model
+    
+  }
   
 }
 


### PR DESCRIPTION
## Description

Cross-quotation references are not possible in Squid, so one needs to write code such as the following to work around the limitation:

```scala
val v = Variable[Int]
code"val $v = 0; ${ foo(code"$v + 1") } * 2"
```

This is a little annoying and encourages bad practices (sharing `Variable` instances, which can lead to unintended – even though type-safe – results).

With variable function insertion, proposed in this PR, one can write instead:

```scala
code"val v = 0; ${ (v:Variable[Int]) => foo(v.toCode) } * 2"
```

## Background and Explanations

One could already use "automatic function lifting," which allows inserting an `OpenCode` to `OpenCode` function, as in:

```scala
code"val v = 0; ${ (oc:OpenCode[Int]) => foo(code"$oc + 1") }(v) * 2"
```

...which produces the same code. However, it means we give up context safety, as we are now manipulating `OpenCode` fragments.

Making this context-safe is not possible without first-class polymorphic functions, as it would require the inserted function to have type `forall C. Code[A,C] => Code[B,C]`. Requiring the instantiation of a class to cope with this (i.e., Scala's way of doing first-class polymorphism) would be way too clunky and inflexible.

Another equivalent approach is to use dependent function types (DFT), so that the inserted function must have type `(v: Variable[A]) => Code[B, v.Ctx]`. Unfortunately, only Dotty currently supports DFT, not Scalac.

Nevertheless, I discovered that a similar effect can be achieved with a little bit of macro instrumentation.

The type inferred by Scalac for `(v:Variable[Int]) => v.toCode` is `Variable[Int] => Code[Int,v.Ctx] forSome { val v: Variable[Int] }`. When a variable function is inserted, the quasiquote macro looks for such an existential type, makes sure that the existential symbol corresponds to the symbol actually bound by the inserted lambda (so that **this mechanism is perfectly type-safe**), and does the work required to wire the variable reference in the inserted code with the one bound in the quote.