### PR TITLE
Support cross-quotation references

### DIFF
--- a/core/src/main/scala/squid/lib/Annotations.scala
+++ b/core/src/main/scala/squid/lib/Annotations.scala
@@ -1,4 +1,4 @@
-// Copyright 2017 EPFL DATA Lab (data.epfl.ch)
+// Copyright 2019 EPFL DATA Lab (data.epfl.ch)
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,17 @@ package squid
 package lib
 
 import scala.annotation.StaticAnnotation
+
+
+// General-purpose annotations:
+
+/** This is used to annotate value definitions (variables, fields, parameters), to indicate that references to the value
+  * should be interpreted as cross-stage-persistent references, meaning that they are not lifted to code, but that code
+  * fragments that reference them carry them around at runtime, and use them when calling `_.run` or `_.compile`. */
+class persist extends StaticAnnotation
+
+
+// Annotations for the effect system:
 
 /** The method has no other effects than the latent effects of closures (or other objects) passed to it. */
 class transparent extends StaticAnnotation

--- a/core/src/main/scala/squid/quasi/QuasiBase.scala
+++ b/core/src/main/scala/squid/quasi/QuasiBase.scala
@@ -342,6 +342,9 @@ self: Base =>
       }
     }
     
+    @compileTimeOnly("The cross-stage persistence annotation '%' has no effect outside of code fragments.")
+    def %[A](a: A): A = a
+    
     import scala.language.dynamics
     object ? extends Dynamic {
       @compileTimeOnly("The `?` syntax can only be used inside quasiquotes and quasicode.")

--- a/core/src/main/scala/squid/quasi/QuasiBase.scala
+++ b/core/src/main/scala/squid/quasi/QuasiBase.scala
@@ -478,6 +478,10 @@ self: Base =>
   @compileTimeOnly("This method is not supposed to be used manually.")
   def $$_varFun[V,T,C](refIdent: V)(vf: Variable[V] => OpenCode[T]): T = ???
   
+  @compileTimeOnly("Cross-quotation reference was never captured. " +
+    "Perhaps you intended to use a cross-stage-persistent reference, which needs the @squid.lib.persist annotation.")
+  def crossQuotation(x: Any): Rep = ???
+  
   // note: the following functions are implicitly inserted by QuasiEmbedder,
   //       so that code"$f(...)" is equivalent to code"${liftOpenFun(f)}(...)"
   implicit def liftOpenFun[A:CodeType,B](qf: OpenCode[A] => OpenCode[B]): OpenCode[A => B] = {

--- a/core/src/main/scala/squid/quasi/QuasiEmbedder.scala
+++ b/core/src/main/scala/squid/quasi/QuasiEmbedder.scala
@@ -767,10 +767,7 @@ class QuasiEmbedder[C <: blackbox.Context](val c: C) {
                 debug("Cross-quotation reference:", x)
                 
                 val sym = x.symbol.asTerm
-                val varType = variableSymbols.getOrElseUpdate(sym, {
-                  val cde = q"val $name: ${baseTree.tpe}#Variable[${x.tpe}] = _root_.scala.Predef.??? ; _root_.scala.Predef.??? : $name.Ctx"
-                  c.typecheck(cde).tpe
-                })
+                val varType = variableSymbols.getOrElseUpdate(sym, internal.singleType(NoPrefix, sym))
                 termScope ::= varType
                 
                 q"${mb.Base}.crossQuotation($x)".asInstanceOf[b.Rep]

--- a/core/src/main/scala/squid/quasi/ScopeAnalyser.scala
+++ b/core/src/main/scala/squid/quasi/ScopeAnalyser.scala
@@ -33,8 +33,16 @@ trait ScopeAnalyser[U <: scala.reflect.api.Universe] extends UniverseHelpers[U] 
   def bases_variables(typ: Type): (List[Type], List[(TermName, Type)]) = {
     //println("[C] "+typ+" : "+typ.getClass)
     typ.dealias match {
+        
+      // We used to have the following case enabled, but I don't think it ever makes sense; OTOH, there are situations
+      // where we'd prefer to keep singleton types precise, and widening them would be wrong!
+      // An example is when we type cross-quotation boundaries, as in code{x:Int => ... code{x} ...}; there, the code
+      // in the middle has type Code[Int, x.type].
+      /*
       case st @ SingleType(pre: Type, sym: Symbol) =>
         bases_variables(sym.typeSignature) // or use 'st.widen'
+      */
+        
       case RefinedType(parents: List[Type], decls: Scope) =>
         val (baseSyms, varSyms) = parents map bases_variables unzip;
         val vars = decls flatMap {

--- a/core/src/test/scala/squid/utils/typing/SingletonTypeTests.scala
+++ b/core/src/test/scala/squid/utils/typing/SingletonTypeTests.scala
@@ -1,0 +1,59 @@
+// Copyright 2019 EPFL DATA Lab (data.epfl.ch)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package squid.utils.typing
+
+import org.scalatest.FunSuite
+import singleton.scope
+
+class SingletonTypeTests extends FunSuite {
+  
+  val a = 0
+  
+  test("Singleton Types of AnyVal Types") {
+    
+    val x = 0
+    val y = 1
+    var z = 2
+    
+    assertCompiles      ("x: scope.x")
+    assertCompiles      ("y: scope.y")
+    
+    assertDoesNotCompile("x: scope.y")
+    assertDoesNotCompile("y: scope.x")
+    // ^ Error: type mismatch; found: y.type (with underlying type Int); required: x.type
+    
+    assertDoesNotCompile("z: scope.z")
+    // ^ Error: type mismatch; found: Int; required: z.type
+    
+    // With a field it does not work, for some reason (probably because we use NoPrefix for the singleType):
+    //a:scope.a
+    // ^ Error: type a is not a member of AnyRef{type y = y.type; type a = a.type; type x = x.type}
+    
+  }
+  
+  test("Singleton Types with Shadowing") {
+    
+    val x = 0
+    val y = 1
+    
+    identity {
+      val x = 1
+      assertCompiles      ("x: scope.x")
+      assertDoesNotCompile("x: scope.y")
+    }
+    
+  }
+  
+}

--- a/src/test/scala/squid/feature/CrossQuotationTests.scala
+++ b/src/test/scala/squid/feature/CrossQuotationTests.scala
@@ -17,6 +17,7 @@ package feature
 
 import squid.lib.persist
 import utils._
+import utils.typing.singleton.scope
 
 /*
 
@@ -46,9 +47,11 @@ class CrossQuotationTests extends MyFunSuite(CrossStageDSL) {
     
     val c0 = code{ x: Int => ${
       
-      //val c: Code[Int,x.type] = code{x+1}
+      //val c: Code[Int, x.type] = code{x+1}
       // ^ Scalac as of 2.12 does not allow taking the .type of a non-AnyRef type
+      val c0: Code[Int, scope.x] = code{x+1}
       val c = code{x+1}
+      c eqt c0
       
       eqt(DSL.crossQuotation(x), code{x}.rep)
       //println(DSL.crossQuotation(x+1)) // Quasiquote Error: Cannot refer to local quoted variable 'x' from outside of quotation.

--- a/src/test/scala/squid/feature/CrossQuotationTests.scala
+++ b/src/test/scala/squid/feature/CrossQuotationTests.scala
@@ -1,0 +1,102 @@
+// Copyright 2019 EPFL DATA Lab (data.epfl.ch)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package squid
+package feature
+
+import squid.lib.persist
+import utils._
+
+/*
+
+TODO: the scope macro
+  scope.x refers to the variable bound by x, possibly cross-quote;
+    can also be a type so we can have Code[T,scope.x], slightly shorter than Code[T,scope.x.Ctx] (maybe not worth it)
+  scope - x removes x from the scope
+
+Q: can we make this work?
+  def f(v: Variable[Int])(c: scope.Code[Int]) = ... // scope should refer to v...
+also, alternatively:
+  def f(v: Variable[Int])(c: Code[Int,scope.v]) = ...
+and even, also:
+  def f(scp: Scope)(c: scp.Code[Int]) = ...
+called as:
+  f(scope)(...)
+though that's not better than just a C type parameter
+
+*/
+class CrossQuotationTests extends MyFunSuite(CrossStageDSL) {
+  import DSL.Predef._
+  import DSL.Quasicodes._
+  
+  def foo[C](cde: Code[String,C]) = code{ ${cde} + "!" }
+  
+  test("Lambda-Bound") {
+    
+    val c0 = code{ x: Int => ${
+      eqt(DSL.crossQuotation(x), code{x}.rep)
+      //println(DSL.crossQuotation(x+1)) // Quasiquote Error: Cannot refer to local quoted variable 'x' from outside of quotation.
+      identity(code{x + 1})
+    }}
+    c0 eqt code"(x:Int) => x+1"
+    val f0 = c0.compile
+    assert(f0(42) == 43)
+    
+    assertCompiles      ("code{ x: Int => ${ println( ); code{   x  } } }")
+    assertDoesNotCompile("code{ x: Int => ${ println(x); code{   x  } } }")
+    assertDoesNotCompile("code{ x: Int => ${ println( ); code{ %(x) } } }")
+    // ^ Error: Quasiquote Error: Cannot refer to local quoted 'x' from outside of quotation.
+    
+    val f1 = code{ (x:Int, y:String) => ${ foo(code{y * x}) } }
+    assert(f1.run.apply(3,"hey!") == "hey!hey!hey!!")
+    
+  }
+  
+  test("Val-Bound") {
+    
+    val c0: ClosedCode[String] = code{ val x = 42; ${
+      
+      foo(code{'ok.name * x})
+      
+    }}
+    c0 eqt code{ val a = 42; 'ok.name * a + "!" }
+    
+    val c1: ClosedCode[String] = code{
+      val x = 42;
+      val y = 'ok.name
+      ${ foo(code{ y * x }) }
+    }
+    c1 eqt code{ val a = 42; val b = 'ok.name; b * a + "!" }
+    
+    // Erroneous use (reported after type checking by @compileTimeOnly):
+    /*
+    val oops2 = 'ko
+    code{oops2.name.length} alsoApply println
+    */
+    // ^ Error: Cross-quotation reference was never captured. Perhaps you intended to use a cross-stage-persistent reference, which needs the @squid.lib.persist annotation.
+    
+  }
+  
+  test("Crossing Several Quotation Boundaries") {
+    
+    val c0: ClosedCode[String => String] = code{ val x = 42; ${
+      identity(code{ y: String => ${
+        foo(code{ y * x }) // 'x' here refers to the one defined two levels out
+      }})
+    }}
+    c0 eqt code{ val a = 42; (b: String) => b * a + "!" }
+    
+  }
+  
+}

--- a/src/test/scala/squid/feature/ImplicitLiftingTests.scala
+++ b/src/test/scala/squid/feature/ImplicitLiftingTests.scala
@@ -1,4 +1,4 @@
-// Copyright 2018 EPFL DATA Lab (data.epfl.ch)
+// Copyright 2019 EPFL DATA Lab (data.epfl.ch)
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 package squid
 package feature
 
+import squid.lib.persist
 import squid.utils._
 
 class ImplicitLiftingTests extends MyFunSuite(CrossStageDSL) {
@@ -35,7 +36,7 @@ class ImplicitLiftingTests extends MyFunSuite(CrossStageDSL) {
   
   test("Cross-Stage Implicit Lifting") {
     
-    implicit val ev: Ordering[MyClass] = Ordering.by(_.hashCode) // local instance value
+    @persist implicit val ev: Ordering[MyClass] = Ordering.by(_.hashCode) // local instance value
     
     val ordCde = implicitly[ClosedCode[Ordering[MyClass]]]
     ordCde eqt c"ev" // cross-stage persistence

--- a/src/test/scala/squid/feature/OpenCodeTests.scala
+++ b/src/test/scala/squid/feature/OpenCodeTests.scala
@@ -1,4 +1,4 @@
-// Copyright 2018 EPFL DATA Lab (data.epfl.ch)
+// Copyright 2019 EPFL DATA Lab (data.epfl.ch)
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 package squid
 package feature
 
+import squid.lib.persist
 import utils._
 
 /** Demonstrating the use of OpenCode when we don't want to track context dependencies. */
@@ -105,7 +106,7 @@ class OpenCodeTests extends MyFunSuite(CrossStageDSL) {
     t1 eqt code{List($(ri)(),$(ri)()).sum}
     assert(t1.close.isEmpty)
     var i = 1
-    val foo = () => i alsoDo {i += 1}
+    @persist val foo = () => i alsoDo {i += 1}
     
     val t2 = code"val $ri = foo; $t1"
     same(t2.close.get, t2.unsafe_asClosedCode)

--- a/src/test/scala/squid/feature/TrickyTypes.scala
+++ b/src/test/scala/squid/feature/TrickyTypes.scala
@@ -54,6 +54,16 @@ class TrickyTypes extends MyFunSuite {
     
   }
   
+  test("Singleton Contexts") {
+    
+    val v = Variable[Int]
+    object M { type C = v.Ctx }
+    val c0: Code[Int,M.C] = c"$v + 1"
+    val c1: ClosedCode[Int => Int] = c"{$v => $c0}"
+    c1 eqt c"{x: Int => x + 1}"
+    
+  }
+  
   
   test("Lambda with Expected Type") {
     import base.Quasicodes._

--- a/src/test/scala/squid/feature/VariableFunctionsInsertion.scala
+++ b/src/test/scala/squid/feature/VariableFunctionsInsertion.scala
@@ -40,6 +40,12 @@ class VariableFunctionsInsertion extends MyFunSuite {
       code"val x = 0; (${code"42"}+1) * 2"
     
     
+    code"{ x: Int => ${ (x: Variable[Int]) => identity(code{ ${x} + 1 }) } }" eqt
+      code"{ y: Int => y + 1 }"
+    
+    // Note: syntax is currently unsupported in quasicode; but there we now have cross-quotation references so it does not seems necessary
+    //code{ x: Int => ${ (x: Variable[Int]) => identity(code{ ${x} + 1 }) } } alsoApply println
+    
     // result of function is the WRONG existential:
     import scala.language.existentials
     val w -> cde = { val v = Variable[Int]; v -> code"$v+1" } 

--- a/src/test/scala/squid/feature/VariableSymbolTests.scala
+++ b/src/test/scala/squid/feature/VariableSymbolTests.scala
@@ -90,6 +90,9 @@ class VariableSymbolTests extends MyFunSuite {
     
     //code{val $v = 0; ${identity(code{$v + 1})}} // TODO enable this syntax, for consistency
     
+    code{ $v: Int => ${ identity(code{ ${v} + 1 }) } } eqt
+      code"{ a: Int => a + 1 }"
+    
   }
   
   


### PR DESCRIPTION
Cross-quotation references (CQR) allow one to write (this works with the changes in this PR):

```scala
code{ x: Int => ${
  println("Constructing code!")
  foo(code{ x + 1 })
}}
```

(notice the call to `foo` at code-generation time, passing it a piece of code that contains an identifier bound in the outer quote)

instead of having to either:

* use an automatically-lifted function, if one doesn't care about contexts (this will only work with `OpenCode` types, as it is unsound otherwise):
```scala
    code{ x: Int => ${ (x: OpenCode[Int]) => foo(code{ ${x} + 1 }) } }
```

 * use a first-class variable symbol:

```scala
    val x = Variable[Int]
    code{ $x => ${ foo(code{ ${x} + 1 }) } }
```

 * use a first-class variable symbol [with syntax sugar](https://github.com/epfldata/squid/pull/53) (currently only works in quasi-_quotes_):

```scala
    code"{ x: Int => ${ (x: Variable[Int]) => foo(code{ ${x} + 1 }) } }"
```

All of these workarounds are quite unwieldy, and the lack of CQR has always been a pain.

CQR is hard to do because of the limited control given to macros, and the order in which macros expand. One of the sticking points has been to make the feature scope-safe, which means that we need to track that the inner quote refers to the outer quote's binding, so it cannot be extruded.

The approach taken here is to use `x.type` as the phantom context requirement associated with a cross-stage reference to the `x` binding. The approach only works in quasi-_code_. I'm pretty sure it cannot be done with quasi-_quotes_ without some sort of annotations (which defeats the purpose; at this point just use variable symbols), due to fundamental type checking and type inference reasons.

This way, one can even mention the context requirements explicitly:

```scala
val c1 = code{ x: String => ${
  val c: Code[Int,x.type] = code{x.length}
  code{${c} + 1}
}}
c1 == code{ a: String => a.length + 1 } // true
```

Note that in current Scala, writing the type explicitly only works if `x` extends `AnyRef` (otherwise Scala doesn't let you write `x.type`), a dumb limitations that is apparently gone from Scala 2.13, fortunately. To work around this problem, [I wrote](https://github.com/epfldata/squid/pull/61/commits/563d5b41bfa9a6436856f6bed1eeffbdc179c87a) a `singleton.scope` macro in `squid.utils.typing`, so that one can always write `singleton.scope.x` to mean `x.type`, even for `AnyVal` types.