### PR TITLE
Implement effectful reification

### DIFF
--- a/core/src/main/scala/squid/lang/EffectfulReification.scala
+++ b/core/src/main/scala/squid/lang/EffectfulReification.scala
@@ -1,0 +1,24 @@
+// Copyright 2019 EPFL DATA Lab (data.epfl.ch)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package squid.lang
+
+/** A trait giving access to the .! and .bind_! effectful reificatiom features. */
+trait EffectfulReification extends Base {
+  
+  def registerBoundRep(r: Rep): BoundVal
+  
+  def registerEffectRep(r: Rep): Unit
+  
+}

--- a/doc/internal/design/Effectful Reification.md
+++ b/doc/internal/design/Effectful Reification.md
@@ -1,0 +1,30 @@
+# Effectful Reification
+
+
+## Design
+
+I decided _note_ make `code"..."` quasiquotes themselves effectful (as in, say, LMS, or the old SC backend).
+Instead, I use _separate_ functions `.!` and `.bind_!` on coe fragments. The main advantage is that pure programs using
+`code"..."` retains the same referentially-transparent meaning, and programs that makes use of effectful reification
+have to be explicit about it.
+It also has the nice property of decoupling effectful reification from the IR being an ANF or similar, where
+_every subexpression_ is automatically let-bound by default.
+
+
+## Typing
+
+Using `.bind_!` produces an `OpenCode` value, because it's not easily possible to track the context of the
+automatically-inserted binding. Conceptually, `.bind_!` should return a `Variable[_ <: T]`, but that gives rise to
+ugly existential types and unclosable code types anyway.
+
+A possible way to solve this woudl be to use syntax `@reified val x = code{...}`, use the symbol of the `x` binding
+itself (similar to what cross-quotation references do), and have a mechanism in the outer QQ to remove such requirements
+from the context.
+
+
+## Syntax
+
+Possible  more lightweight alternatives could be `code{}` and `code_!{}`.
+This could probably be done using a different to-level macro which would call calls `wrapEffectfulConstruct` instead of
+`wrapConstruct` 
+

--- a/doc/internal/design/Effectful Reification.md
+++ b/doc/internal/design/Effectful Reification.md
@@ -3,9 +3,9 @@
 
 ## Design
 
-I decided _note_ make `code"..."` quasiquotes themselves effectful (as in, say, LMS, or the old SC backend).
+I decided _not_ to make `code"..."` quasiquotes themselves effectful (as in, say, LMS, or the old SC backend).
 Instead, I use _separate_ functions `.!` and `.bind_!` on coe fragments. The main advantage is that pure programs using
-`code"..."` retains the same referentially-transparent meaning, and programs that makes use of effectful reification
+`code"..."` retains the same referentially-transparent meaning, and programs that wish to make use of effectful reification
 have to be explicit about it.
 It also has the nice property of decoupling effectful reification from the IR being an ANF or similar, where
 _every subexpression_ is automatically let-bound by default.

--- a/src/main/scala/squid/ir/EffectfulASTReification.scala
+++ b/src/main/scala/squid/ir/EffectfulASTReification.scala
@@ -28,11 +28,15 @@ trait EffectfulASTReification extends AST with squid.lang.EffectfulReification {
   
   def registerBoundRep(r: Rep): BoundVal = {
     val v = new AutomaticVal(r)
-    reificationContext.head += v
+    reificationContext.headOption.getOrElse(
+      throw IRException("Cannot register binding outside of quoted context.")
+    ) += v
     v
   }
   def registerEffectRep(r: Rep): Unit = {
-    reificationContext.head += new AutomaticEffect(r)
+    reificationContext.headOption.getOrElse(
+      throw IRException("Cannot register effect outside of quoted context.")
+    ) += new AutomaticEffect(r)
   }
   
   override def wrapConstruct(mkRep: => Rep): Rep =

--- a/src/main/scala/squid/ir/EffectfulASTReification.scala
+++ b/src/main/scala/squid/ir/EffectfulASTReification.scala
@@ -1,0 +1,60 @@
+// Copyright 2019 EPFL DATA Lab (data.epfl.ch)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package squid.ir
+
+import scala.collection.mutable
+import squid.utils._
+
+/** A trait to mix into any AST IR to give access to the .! and .bind_! effectful reificatiom features. */
+trait EffectfulASTReification extends AST with squid.lang.EffectfulReification {
+  
+  sealed trait RegisteredRep
+  class AutomaticVal(val bound: Rep) extends BoundVal("_auto")(bound.typ, Nil) with RegisteredRep
+  class AutomaticEffect(val rep: Rep) extends RegisteredRep
+  
+  protected var reificationContext = List.empty[mutable.ListBuffer[RegisteredRep]]
+  
+  def registerBoundRep(r: Rep): BoundVal = {
+    val v = new AutomaticVal(r)
+    reificationContext.head += v
+    v
+  }
+  def registerEffectRep(r: Rep): Unit = {
+    reificationContext.head += new AutomaticEffect(r)
+  }
+  
+  override def wrapConstruct(mkRep: => Rep): Rep =
+    wrapEffectfulReification(super.wrapConstruct(mkRep))
+  
+  def wrapEffectfulReification(mkRep: => Rep): Rep = {
+    val oldCtx = reificationContext
+    val curCtx = mutable.ListBuffer.empty[RegisteredRep]
+    reificationContext = curCtx :: oldCtx
+    try {
+      val res = mkRep
+      val inserted = curCtx.toList
+      inserted.foldRight(res) {
+        case (v: AutomaticVal, cur) => letin(v, v.bound, cur, cur.typ)
+        case (e: AutomaticEffect, Imperative(xs,x)) => Imperative(e.rep +: xs : _*)(x)
+        case (e: AutomaticEffect, cur) => Imperative(e.rep)(cur)
+      }
+    } finally reificationContext = oldCtx
+  }
+  
+  override abstract def lambda(params: List[BoundVal], body: => Rep) = {
+    super.lambda(params, wrapEffectfulReification(body))
+  }
+  
+}

--- a/src/test/scala/squid/ir/EffectfulReificationTests.scala
+++ b/src/test/scala/squid/ir/EffectfulReificationTests.scala
@@ -1,0 +1,92 @@
+// Copyright 2019 EPFL DATA Lab (data.epfl.ch)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package squid
+package ir
+
+object EffectfulReificationTests {
+  object IR extends SimpleAST with EffectfulASTReification
+}
+class EffectfulReificationTests extends MyFunSuite(EffectfulReificationTests.IR) {
+  import DSL.Predef._
+  import DSL.Quasicodes._
+  
+  test("Manual Effectful Reification") {
+    
+    val cde = code{ (x: Int) => ${
+      import DSL._
+      val r = const(42) |> registerBoundRep
+      val s = c"${Code[Int,Any](r |> readVal)} * ${Code[Int,Any](crossQuotation(x))} + 1".rep |> registerBoundRep
+      Code[Int,Any](s |> readVal)
+    }}
+    cde eqt c""" (x: Int) => {
+      val r = 42
+      val s = r * x + 1
+      s
+    }"""
+    
+  }
+  
+  test("Effectful Reification") {
+    
+    // Effectful reifications yield OpenCode, because there is no easy way to track their context...
+    val cde: OpenCode[Int => Int] = code(x => ${
+      val r = c"42".bind_!
+      val s = c"$r * x + 1".bind_!
+      c"println($r)".!
+      c"println($s)".bind_!
+      s
+    })
+    cde eqt c""" (x: Int) => {
+      val r = 42
+      val s = r * x + 1
+      println(r)
+      val _y = println(s)
+      s
+    }"""
+    
+  }
+  
+  test("Effectful Reification Without Bindings") {
+    
+    val ls = List(c"1", c"2", c"3")
+    
+    // unrolled loop example
+    val cde: ClosedCode[Int => Int] = code{ x: Int =>
+      var res = 0
+      
+      // TODO implement this?
+      //${ for (e <- ls) c"res = res + $e * x".! }
+      // ^ Error:(67, 24) Embedding Error: Unsupported feature: update to cross-quotation or cross-stage mutable variable 'res'
+      
+      val plus = (v: Int) => res += v
+      ${ for (e <- ls) c"plus($e * x)".! }  // uses automatic convertion from () to code"()", imported from Quasicodes._
+      
+      println(res)
+      res
+    }
+    cde eqt c""" (x: Int) => {
+      var res = 0
+      val plus = (v: Int) => res += v
+      plus(1 * x)
+      plus(2 * x)
+      plus(3 * x)
+      ()
+      println(res)
+      res
+    }"""
+    
+  }
+  
+}

--- a/src/test/scala/squid/ir/EffectfulReificationTests.scala
+++ b/src/test/scala/squid/ir/EffectfulReificationTests.scala
@@ -56,6 +56,12 @@ class EffectfulReificationTests extends MyFunSuite(EffectfulReificationTests.IR)
       s
     }"""
     
+    assert(intercept[IRException](code"'oops".!).msg ==
+      "Cannot register effect outside of quoted context.")
+    
+    assert(intercept[IRException](code"'oops".bind_!).msg ==
+      "Cannot register binding outside of quoted context.")
+    
   }
   
   test("Effectful Reification Without Bindings") {

--- a/src/test/scala/squid/ir/EffectfulReificationTests.scala
+++ b/src/test/scala/squid/ir/EffectfulReificationTests.scala
@@ -71,12 +71,29 @@ class EffectfulReificationTests extends MyFunSuite(EffectfulReificationTests.IR)
       println(res)
       res
     }
-    cde eqt c""" (x: Int) => {
+    cde eqt c"""{ x: Int =>
       var res = 0
       res = res + (1 * x)
       res = res + (2 * x)
       res = res + (3 * x)
       ()
+      println(res)
+      res
+    }"""
+    
+    // Just for completeness, the standard alternative without effectful reification:
+    import utils.typing.singleton.scope
+    val cde2: ClosedCode[Int => Int] = code{ x: Int => ${
+      var res: Code[Int,scope.x] = code{0}
+      for (e <- ls) res = code"${res} + $e * x"
+      code{
+        val r = ${res}
+        println(r)
+        r
+      }
+    }}
+    cde2 eqt c"""{ x: Int =>
+      val res = 0 + (1 * x) + (2 * x) + (3 * x)
       println(res)
       res
     }"""

--- a/src/test/scala/squid/ir/EffectfulReificationTests.scala
+++ b/src/test/scala/squid/ir/EffectfulReificationTests.scala
@@ -62,26 +62,20 @@ class EffectfulReificationTests extends MyFunSuite(EffectfulReificationTests.IR)
     
     val ls = List(c"1", c"2", c"3")
     
-    // unrolled loop example
+    // Unrolled loop example:
     val cde: ClosedCode[Int => Int] = code{ x: Int =>
       var res = 0
       
-      // TODO implement this?
-      //${ for (e <- ls) c"res = res + $e * x".! }
-      // ^ Error:(67, 24) Embedding Error: Unsupported feature: update to cross-quotation or cross-stage mutable variable 'res'
-      
-      val plus = (v: Int) => res += v
-      ${ for (e <- ls) c"plus($e * x)".! }  // uses automatic convertion from () to code"()", imported from Quasicodes._
+      ${ for (e <- ls) c"res += $e * x".! }  // uses automatic convertion from () to code"()", imported from Quasicodes._
       
       println(res)
       res
     }
     cde eqt c""" (x: Int) => {
       var res = 0
-      val plus = (v: Int) => res += v
-      plus(1 * x)
-      plus(2 * x)
-      plus(3 * x)
+      res = res + (1 * x)
+      res = res + (2 * x)
+      res = res + (3 * x)
       ()
       println(res)
       res


### PR DESCRIPTION
It can be useful to have quoted code (especially effectful one) be registered in the outer quoted scope automatically. It's a commonly used technique in LMS, for example, where in fact _any_ staged code gets automatically registered in an enclosing scope. Here, I took a more conservative/principled approach.

I decided _not_ to make `code"..."` quasiquotes themselves effectful (as in, say, LMS, or the old SC backend). Instead, I use _separate_ functions `.!` and `.bind_!` on coe fragments. The main advantage is that pure programs using `code"..."` retains the same referentially-transparent meaning, and programs that wish to make use of effectful reification have to be explicit about it. It also has the nice property of decoupling effectful reification from the IR being an ANF or similar, where _every subexpression_ is automatically let-bound by default.

To be fair, the purpose of this feature is in part that it looks nice in papers, as it allows showing code with less noise for simple examples, like staged loop unrolling. Consider:

```scala
    val ls = List(code{1}, code{2}, code{3})
    
    // Unrolled loop example:
    val cde: ClosedCode[Int => Int] = code{ x: Int =>
      var res = 0
      ${ for (e <- ls) code{ res += ${e} * x }.! }
      println(res)
      res
    }
    // Equivalent to:
    val cde: ClosedCode[Int => Int] = code{ x: Int =>
      var res = 0
      res = res + (1 * x)
      res = res + (2 * x)
      res = res + (3 * x)
      println(res)
      res
    }
```

Instead of having to use a fold or even an effectful loop with a `Code` variable, which exposes complicated types upfront:

```scala
    val cde: ClosedCode[Int => Int] = code{ x: Int => ${
      var res: Code[Int,x.type] = code{0}
      for (e <- ls) res = code{${res} + ${e} * x }
      code{
        val r = ${res}
        println(r)
        r
      }
    }}
```

...which generates slightly better code, though, since the mutable variable is staged away:

```scala
// Generated:
code"""((x_0: scala.Int) => {
  val r_1 = (0).+((1).*(x_0)).+((2).*(x_0)).+((3).*(x_0));
  scala.Predef.println(r_1);
  r_1
})"""
```